### PR TITLE
Correct type for items in relationship

### DIFF
--- a/sqlalchemy_jsonapi/serializer.py
+++ b/sqlalchemy_jsonapi/serializer.py
@@ -366,7 +366,7 @@ class JSONAPI(object):
                     if key in local_fields:
                         to_ret['relationships'][key]['data'].append({
                             'id': item.id,
-                            'type': api_type
+                            'type': item.__jsonapi_type__
                         })
 
                     if key in include.keys():


### PR DESCRIPTION
In the current implementation it seems like the type of the related item is being set to the current item.
Should it instead be that the type field of related item type of the related item?
e.g. in this json response given an item object and a category object, when returning an item.

    {
      "data": [
      {
      "attributes": {
        "name": "Item 1"
      },
      "id": 1,
      "relationships": {
        "category": {
          "data": [
            {
              "id": 1,
              "type": "item"   // <----------should be category
            }
          ]
        },
      "type": "item"
    }]