### PR TITLE
Models with inheritance and __json_api_type__

### DIFF
--- a/sqlalchemy_jsonapi/serializer.py
+++ b/sqlalchemy_jsonapi/serializer.py
@@ -224,7 +224,7 @@ class JSONAPI(object):
                 continue
 
             prepped_name = underscore(pluralize(name))
-            api_type = getattr(model, '__jsonapi_type__', prepped_name)
+            api_type = getattr(model, '__jsonapi_type_override__', prepped_name)
 
             model.__jsonapi_attribute_descriptors__ = {}
             model.__jsonapi_rel_desc__ = {}


### PR DESCRIPTION
I think this line exists today so users can override the __json_api_type__ locally on a specific model.
However, it appears that since the override name is the same as the internal name, if the models are using inheritance the __json_api_type__ only gets set on which ever models get processed first.  Once the base class loads the other models won't set the __json_api_type__. 

The proposed change here would be a breaking change if anyone was overridding the __json_api_type__ directly on their models.