### PR TITLE
remove hard dependency on flask

### DIFF
--- a/sqlalchemy_jsonapi/__init__.py
+++ b/sqlalchemy_jsonapi/__init__.py
@@ -1,4 +1,8 @@
-from .flaskext import FlaskJSONAPI, Method, Endpoint
+try:
+    from .flaskext import FlaskJSONAPI, Method, Endpoint
+except ImportError:
+    FlaskJSONAPI, Method, Endpoint = None, None, None
+
 from .serializer import (JSONAPI, AttributeActions, RelationshipActions,
                          Permissions, attr_descriptor, relationship_descriptor,
                          permission_test, INTERACTIVE_PERMISSIONS,


### PR DESCRIPTION
Allow the serializer to be imported when flask is not installed