### PR TITLE
Support Decimal type in JSON serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ target/
 pyvenv.cfg
 pip-selfcheck.json
 
+# PyCharm
+.idea
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pathtools==0.1.2
 py==1.4.31                # via pytest
 pycparser==2.14           # via cffi
 pytest==2.7.3
+simplejson==3.8.2
 six==1.10.0               # via bcrypt, sqlalchemy-utils
 SQLAlchemy-Utils==0.30.16
 sqlalchemy==1.0.13

--- a/sqlalchemy_jsonapi/flaskext.py
+++ b/sqlalchemy_jsonapi/flaskext.py
@@ -6,7 +6,7 @@ MIT License
 """
 
 import datetime
-import json
+import simplejson as json
 import uuid
 from functools import wraps
 
@@ -34,6 +34,7 @@ class JSONAPIEncoder(json.JSONEncoder):
         elif callable(value):
             return str(value)
         return json.JSONEncoder.default(self, value)
+
 
 #: The views to generate
 views = [
@@ -235,7 +236,7 @@ class FlaskJSONAPI(object):
                 response = override(exc, results)
             rendered_response = make_response('')
             if response.status_code != 204:
-                data = json.dumps(response.data, cls=self.json_encoder)
+                data = json.dumps(response.data, cls=self.json_encoder, use_decimal=True)
                 rendered_response = make_response(data)
             rendered_response.status_code = response.status_code
             rendered_response.content_type = 'application/vnd.api+json'


### PR DESCRIPTION
SQLa Numeric types get returned as decimal.Decimal
objects. simplejson has support for this, whereas
the builtin json module does not and there's no clean
way to subclass it in a way that it won't convert
the value to a JSON string.

Fixes #23
