### PR TITLE
Make the dasherize behavior optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ api = FlaskJSONAPI(app, db)
 # Or, for factory-style applications
 api = FlaskJSONAPI()
 api.init_app(app, db)
+
+# To disable using hyphens as word-separators, disable the dasherize option
+api = FlaskJSONAPI(app, db, options={'dasherize': False})
 ```
 
 ## Quick usage without Flask

--- a/sqlalchemy_jsonapi/flaskext.py
+++ b/sqlalchemy_jsonapi/flaskext.py
@@ -85,7 +85,8 @@ class FlaskJSONAPI(object):
                  app=None,
                  sqla=None,
                  namespace='api',
-                 route_prefix='/api'):
+                 route_prefix='/api',
+                 options=None):
         """
         Initialize the adapter.  If app isn't passed here, it should be passed
         in init_app.
@@ -100,9 +101,10 @@ class FlaskJSONAPI(object):
         self._handler_chains = dict()
 
         if app is not None:
-            self._setup_adapter(namespace, route_prefix)
+            self._setup_adapter(namespace, route_prefix, options=options)
 
-    def init_app(self, app, sqla, namespace='api', route_prefix='/api'):
+    def init_app(self, app, sqla, namespace='api', route_prefix='/api',
+                 options=None):
         """
         Initialize the adapter if it hasn't already been initialized.
 
@@ -114,7 +116,7 @@ class FlaskJSONAPI(object):
         self.app = app
         self.sqla = sqla
 
-        self._setup_adapter(namespace, route_prefix)
+        self._setup_adapter(namespace, route_prefix, options=options)
 
     def wrap_handler(self, api_types, methods, endpoints):
         """
@@ -156,14 +158,18 @@ class FlaskJSONAPI(object):
 
         return wrapped
 
-    def _setup_adapter(self, namespace, route_prefix):
+    def _setup_adapter(self, namespace, route_prefix, options=None):
         """
         Initialize the serializer and loop through the views to generate them.
 
         :param namespace: Prefix for generated endpoints
         :param route_prefix: Prefix for route patterns
         """
-        self.serializer = JSONAPI(self.sqla.Model, prefix='{}://{}{}'.format(self.app.config['PREFERRED_URL_SCHEME'], self.app.config['SERVER_NAME'], route_prefix))
+        self.serializer = JSONAPI(self.sqla.Model,
+                                  prefix='{}://{}{}'.format(self.app.config['PREFERRED_URL_SCHEME'],
+                                                            self.app.config['SERVER_NAME'],
+                                                            route_prefix),
+                                  options=options)
         for view in views:
             method, endpoint = view
             pattern = route_prefix + endpoint.value

--- a/sqlalchemy_jsonapi/tests/test_serializer.py
+++ b/sqlalchemy_jsonapi/tests/test_serializer.py
@@ -1,4 +1,5 @@
 from app import api
+from sqlalchemy_jsonapi import JSONAPI
 import uuid
 
 
@@ -9,3 +10,13 @@ def test_include_different_types_same_id(session, comment):
 
     r = api.serializer.get_resource(session, {'include': 'post,author'}, 'blog-comments', comment.id)
     assert len(r.data['included']) == 2
+
+
+def test_no_dasherize(session, comment):
+    api.serializer = JSONAPI(api.serializer.base, api.serializer.prefix,
+                             options={'dasherize': False})
+
+    r = api.serializer.get_resource(session, {}, 'blog_comments', comment.id)
+    assert r.data['data']['type'] == 'blog_comments'
+
+    api.serializer = JSONAPI(api.serializer.base, api.serializer.prefix)


### PR DESCRIPTION
The spec doesn't require it, although it is recommended.
I personally don't want the behavior because I want
my client attributes to match those in the database.

Fixes #24
