### PR TITLE
Fix fetching of AssertionError message for Python 3

### DIFF
--- a/sqlalchemy_jsonapi/serializer.py
+++ b/sqlalchemy_jsonapi/serializer.py
@@ -906,7 +906,7 @@ class JSONAPI(object):
             raise ValidationError(str(e.orig))
         except AssertionError as e:
             session.rollback()
-            raise ValidationError(e.msg)
+            raise ValidationError(getattr(e, 'msg', str(e))
         except TypeError as e:
             session.rollback()
             raise ValidationError('Incompatible data type')
@@ -1043,7 +1043,7 @@ class JSONAPI(object):
             raise ValidationError(str(e.orig))
         except AssertionError as e:
             session.rollback()
-            raise ValidationError(e.msg)
+            raise ValidationError(getattr(e, 'msg', str(e)))
         except TypeError as e:
             session.rollback()
             raise ValidationError('Incompatible data type')


### PR DESCRIPTION
Exceptions in Python 3 no longer contain a `msg` attribute. Instead the exception message is accessible from the exception object directly.

In order to maintain Python 2 support, attempt to fetch the message from `e.msg` and use `str(e)` as a default if the attribute does not exist.

I was going to add a test for this but I saw all the existing tests are currently commented out.  I figured you were likely doing some refactoring and hadn't gotten to the tests yet.  Perhaps you are already fixing this issue as part of your work as well.  Regardless, I thought I'd throw up a PR in case it is useful to you.

Fixes #28
