### PR TITLE
Add tox support for running tests on multiple pythons

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27,py3
+
+[testenv]
+use_develop=True
+deps=-r{toxinidir}/requirements.txt
+commands=py.test
+
+[testenv:dandruff]
+deps=-r{toxinidir}/requirements.txt
+     flake8
+commands=flake8 {toxinidir}/sqlalchemy_jsonapi


### PR DESCRIPTION
I know we have Travis to run tests on multiple pythons. I totally agree that you should _install_ your package into the test environment. I don't want to do that all the time. Enter tox.