### PR TITLE
Raise ValidationError with str(e) rather than e.msg

### DIFF
--- a/sqlalchemy_jsonapi/serializer.py
+++ b/sqlalchemy_jsonapi/serializer.py
@@ -940,7 +940,7 @@ class JSONAPI(object):
             raise ValidationError(str(e.orig))
         except AssertionError as e:
             session.rollback()
-            raise ValidationError(e.msg)
+            raise ValidationError(str(e))
         except TypeError as e:
             session.rollback()
             raise ValidationError('Incompatible data type')
@@ -1079,7 +1079,7 @@ class JSONAPI(object):
             raise ValidationError(str(e.orig))
         except AssertionError as e:
             session.rollback()
-            raise ValidationError(e.msg)
+            raise ValidationError(str(e))
         except TypeError as e:
             session.rollback()
             raise ValidationError('Incompatible data type')


### PR DESCRIPTION
In `patch_resource` and `post_collection` we were excepting an AssertionError and then raising a custom ValidationError from the errors.py file. For example, 
```
        except AssertionError as e:
            session.rollback()
            raise ValidationError(e.msg)
```
The problem is that there is no msg attribute on the exception.

While I tried to change this to be `ValidationError(e)` instead, this raises a `TypeError` in the `json.JSONEncoder` since the AssertionError is not JSON serializable.

Thus the easiest option that also keeps our tests passing is to do it as such
```
        except AssertionError as e:
            session.rollback()
            raise ValidationError(str(e))
```