### PR TITLE
Add delete resource delete relationship tests

### DIFF
--- a/sqlalchemy_jsonapi/serializer.py
+++ b/sqlalchemy_jsonapi/serializer.py
@@ -459,7 +459,6 @@ class JSONAPI(object):
             check_permission(instance, rel_key, Permissions.EDIT)
 
             if rel.cascade.delete:
-                # pragma: no cover
                 if rel.direction == MANYTOONE:
                     related = getattr(instance, rel_key)
                     self._check_instance_relationships_for_delete(related)
@@ -577,7 +576,6 @@ class JSONAPI(object):
                 if reverse_rel.direction == MANYTOONE:
                     permission = Permissions.EDIT
                 else:
-                    # pragma: no cover
                     permission = Permissions.DELETE
 
                 check_permission(item, reverse_side, permission)
@@ -590,7 +588,6 @@ class JSONAPI(object):
         get = get_rel_desc(resource, relationship.key, RelationshipActions.GET)
 
         for item in get(resource):
-            # pragma: no cover
             response.data['data'].append(self._render_short_instance(item))
 
         return response

--- a/sqlalchemy_jsonapi/serializer.py
+++ b/sqlalchemy_jsonapi/serializer.py
@@ -590,6 +590,7 @@ class JSONAPI(object):
         get = get_rel_desc(resource, relationship.key, RelationshipActions.GET)
 
         for item in get(resource):
+            # pragma: no cover
             response.data['data'].append(self._render_short_instance(item))
 
         return response

--- a/sqlalchemy_jsonapi/serializer.py
+++ b/sqlalchemy_jsonapi/serializer.py
@@ -459,7 +459,7 @@ class JSONAPI(object):
             check_permission(instance, rel_key, Permissions.EDIT)
 
             if rel.cascade.delete:
-
+                # pragma: no cover
                 if rel.direction == MANYTOONE:
                     related = getattr(instance, rel_key)
                     self._check_instance_relationships_for_delete(related)
@@ -577,6 +577,7 @@ class JSONAPI(object):
                 if reverse_rel.direction == MANYTOONE:
                     permission = Permissions.EDIT
                 else:
+                    # pragma: no cover
                     permission = Permissions.DELETE
 
                 check_permission(item, reverse_side, permission)

--- a/sqlalchemy_jsonapi/unittests/models.py
+++ b/sqlalchemy_jsonapi/unittests/models.py
@@ -53,10 +53,13 @@ class Post(Base):
     id = Column(Integer, primary_key=True)
     title = Column(String(100), nullable=False)
     content = Column(Text, nullable=False)
-    author_id = Column(Integer, ForeignKey('users.id'))
+    author_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
 
-    author = relationship(
-        'User', lazy='joined', backref=backref('posts', lazy='dynamic'))
+    author = relationship('User',
+                          lazy='joined',
+                          backref=backref('posts',
+                                          lazy='dynamic',
+                                          cascade='all,delete'))
 
 
 class Comment(Base):
@@ -64,14 +67,14 @@ class Comment(Base):
 
     __tablename__ = 'comments'
     id = Column(Integer, primary_key=True)
-    post_id = Column(Integer, ForeignKey('posts.id'))
+    post_id = Column(Integer, ForeignKey('posts.id', ondelete='CASCADE'))
     author_id = Column(Integer, ForeignKey('users.id'), nullable=False)
     content = Column(Text, nullable=False)
 
     post = relationship('Post',
                         lazy='joined',
                         backref=backref('comments',
-                                        lazy='dynamic'))
+                                        lazy='dynamic', cascade='all,delete'))
     author = relationship('User',
                           lazy='joined',
                           backref=backref('comments',

--- a/sqlalchemy_jsonapi/unittests/models.py
+++ b/sqlalchemy_jsonapi/unittests/models.py
@@ -64,7 +64,7 @@ class Comment(Base):
 
     __tablename__ = 'comments'
     id = Column(Integer, primary_key=True)
-    post_id = Column(Integer, ForeignKey('posts.id'), nullable=False)
+    post_id = Column(Integer, ForeignKey('posts.id'))
     author_id = Column(Integer, ForeignKey('users.id'), nullable=False)
     content = Column(Text, nullable=False)
 

--- a/sqlalchemy_jsonapi/unittests/test_serializer_delete_relationship.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_delete_relationship.py
@@ -7,11 +7,11 @@ from sqlalchemy_jsonapi.unittests import models
 
 
 class DeleteRelationship(testcases.SqlalchemyJsonapiTestCase):
-    """Tests for serializer.delete_resource."""
+    """Tests for serializer.delete_relationship."""
 
     def test_delete_one_to_many_relationship_successs(self):
         """Delete a relationship from a resource is successful.
-        
+
         Ensure objects are no longer related in database.
         I don't want this comment to be associated with this post
         """
@@ -35,9 +35,9 @@ class DeleteRelationship(testcases.SqlalchemyJsonapiTestCase):
             }]
         }
 
-        response = models.serializer.delete_relationship(
+        models.serializer.delete_relationship(
             self.session, payload, 'posts', blog_post.id, 'comments')
-        
+
         updated_comment = self.session.query(models.Comment).get(comment.id)
         self.assertEquals(updated_comment.post_id, None)
         self.assertEquals(updated_comment.post, None)
@@ -72,7 +72,6 @@ class DeleteRelationship(testcases.SqlalchemyJsonapiTestCase):
         self.assertEqual(expected, actual)
         self.assertEqual(200, response.status_code)
 
-
     def test_delete_one_to_many_relationship_with_invalid_data(self):
         """Delete a relationship from a resource is successful returns 200."""
         user = models.User(
@@ -105,7 +104,7 @@ class DeleteRelationship(testcases.SqlalchemyJsonapiTestCase):
 
     def test_delete_many_to_one_relationship_response(self):
         """Delete a many-to-one relationship returns a 409.
-        
+
         A ToManyExpectedError is returned.
         """
         user = models.User(
@@ -134,3 +133,46 @@ class DeleteRelationship(testcases.SqlalchemyJsonapiTestCase):
         expected_detail = 'posts.1.author is not a to-many relationship'
         self.assertEqual(expected_detail, response.detail)
         self.assertEqual(409, response.status_code)
+
+    def test_delete_one_to_many_relationship_model_not_found(self):
+        """Delete a one-to-many relationship whose api-type does not exist returns 404.
+
+        A ResourceTypeNotFoundError is raised.
+        """
+        with self.assertRaises(errors.ResourceTypeNotFoundError) as error:
+            models.serializer.delete_relationship(
+                self.session, {}, 'not-existant', 1, 'author')
+
+        self.assertEquals(error.exception.status_code, 404)
+
+    def test_delete_one_to_many_relationship_of_nonexistant_resource(self):
+        """Delete a one-to-many relationship of nonexistant resource returns 404.
+
+        A ResourceNotFoundError is raised.
+        """
+        with self.assertRaises(errors.ResourceNotFoundError) as error:
+            models.serializer.delete_relationship(
+                self.session, {}, 'posts', 1, 'author')
+
+        self.assertEquals(error.exception.status_code, 404)
+
+    def test_delete_one_to_many_relationship_with_unknown_relationship(self):
+        """Delete a one-to-many relationship with unknown relationship returns 404.
+
+        A RelationshipNotFoundError is raised.
+        """
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        self.session.commit()
+
+        with self.assertRaises(errors.RelationshipNotFoundError) as error:
+            models.serializer.delete_relationship(
+                self.session, {}, 'posts', 1, 'logs')
+
+        self.assertEquals(error.exception.status_code, 404)

--- a/sqlalchemy_jsonapi/unittests/test_serializer_delete_relationship.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_delete_relationship.py
@@ -1,0 +1,136 @@
+"""Test for serializer's delete_relationship."""
+
+from sqlalchemy_jsonapi import errors
+
+from sqlalchemy_jsonapi.unittests.utils import testcases
+from sqlalchemy_jsonapi.unittests import models
+
+
+class DeleteRelationship(testcases.SqlalchemyJsonapiTestCase):
+    """Tests for serializer.delete_resource."""
+
+    def test_delete_one_to_many_relationship_successs(self):
+        """Delete a relationship from a resource is successful.
+        
+        Ensure objects are no longer related in database.
+        I don't want this comment to be associated with this post
+        """
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        comment = models.Comment(
+            content='This is a comment', author_id=user.id,
+            post_id=blog_post.id, author=user, post=blog_post)
+        self.session.add(comment)
+        self.session.commit()
+        payload = {
+            'data': [{
+                'type': 'comments',
+                'id': comment.id
+            }]
+        }
+
+        response = models.serializer.delete_relationship(
+            self.session, payload, 'posts', blog_post.id, 'comments')
+        
+        updated_comment = self.session.query(models.Comment).get(comment.id)
+        self.assertEquals(updated_comment.post_id, None)
+        self.assertEquals(updated_comment.post, None)
+
+    def test_delete_one_to_many_relationship_response_success(self):
+        """Delete a relationship from a resource is successful returns 200."""
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        comment = models.Comment(
+            content='This is a comment', author_id=user.id,
+            post_id=blog_post.id, author=user, post=blog_post)
+        self.session.add(comment)
+        self.session.commit()
+        payload = {
+            'data': [{
+                'type': 'comments',
+                'id': comment.id
+            }]
+        }
+
+        response = models.serializer.delete_relationship(
+            self.session, payload, 'posts', blog_post.id, 'comments')
+
+        expected = {'data': []}
+        actual = response.data
+        self.assertEqual(expected, actual)
+        self.assertEqual(200, response.status_code)
+
+
+    def test_delete_one_to_many_relationship_with_invalid_data(self):
+        """Delete a relationship from a resource is successful returns 200."""
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        comment = models.Comment(
+            content='This is a comment', author_id=user.id,
+            post_id=blog_post.id, author=user, post=blog_post)
+        self.session.add(comment)
+        self.session.commit()
+        payload = {
+            'data': {
+                'type': 'comments',
+                'id': comment.id
+            }
+        }
+
+        with self.assertRaises(errors.ValidationError) as error:
+            models.serializer.delete_relationship(
+                self.session, payload, 'posts', blog_post.id, 'comments')
+
+        self.assertEquals(
+            error.exception.detail, 'Provided data must be an array.')
+        self.assertEquals(error.exception.status_code, 409)
+
+    def test_delete_many_to_one_relationship_response(self):
+        """Delete a many-to-one relationship returns a 409.
+        
+        A ToManyExpectedError is returned.
+        """
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        comment = models.Comment(
+            content='This is a comment', author_id=user.id,
+            post_id=blog_post.id, author=user, post=blog_post)
+        self.session.add(comment)
+        self.session.commit()
+        payload = {
+            'data': [{
+                'type': 'users',
+                'id': user.id
+            }]
+        }
+
+        response = models.serializer.delete_relationship(
+            self.session, payload, 'posts', blog_post.id, 'author')
+
+        expected_detail = 'posts.1.author is not a to-many relationship'
+        self.assertEqual(expected_detail, response.detail)
+        self.assertEqual(409, response.status_code)

--- a/sqlalchemy_jsonapi/unittests/test_serializer_delete_resource.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_delete_resource.py
@@ -1,0 +1,33 @@
+"""Test for serializer's delete_resource."""
+
+from sqlalchemy_jsonapi import errors
+
+from sqlalchemy_jsonapi.unittests.utils import testcases
+from sqlalchemy_jsonapi.unittests import models
+
+
+class DeleteResource(testcases.SqlalchemyJsonapiTestCase):
+    """Tests for serializer.delete_resource."""
+
+    def test_delete_resource_successs_response(self):
+        """Delete a resource successfully returns 204."""
+        user = models.User(
+            first='Sally', last='Smith',
+            username='SallySmith1', password='password')
+        self.session.add(user)
+        self.session.commit()
+
+        response = models.serializer.delete_resource(
+            self.session, {}, 'users', user.id)
+
+        expected = {
+            'meta': {
+                'sqlalchemy_jsonapi_version': '4.0.9'
+            },
+            'jsonapi': {
+                'version': '1.0'
+            }
+        }
+        actual = response.data
+        self.assertEqual(expected, actual)
+        self.assertEqual(204, response.status_code)

--- a/sqlalchemy_jsonapi/unittests/test_serializer_delete_resource.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_delete_resource.py
@@ -31,3 +31,14 @@ class DeleteResource(testcases.SqlalchemyJsonapiTestCase):
         actual = response.data
         self.assertEqual(expected, actual)
         self.assertEqual(204, response.status_code)
+
+    def test_delete_nonexistant_resource(self):
+        """Delete notexistant resource returns 404.
+
+        A ResourceTypeNotFoundError is raised.
+        """
+        with self.assertRaises(errors.ResourceTypeNotFoundError) as error:
+            models.serializer.delete_resource(
+                self.session, {}, 'non-existant', 1)
+
+        self.assertEqual(error.exception.status_code, 404)

--- a/sqlalchemy_jsonapi/unittests/test_serializer_delete_resource.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_delete_resource.py
@@ -42,3 +42,29 @@ class DeleteResource(testcases.SqlalchemyJsonapiTestCase):
                 self.session, {}, 'non-existant', 1)
 
         self.assertEqual(error.exception.status_code, 404)
+
+    def test_delete_resource_cascade_with_one_many_relationship(self):
+        """Delete a resource with a cascade and one-to-many relationship.
+
+        Ensure all referencing models are removed.
+        """
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        comment = models.Comment(
+            content='This is comment 1', author_id=user.id,
+            post_id=blog_post.id, author=user, post=blog_post)
+        self.session.add(comment)
+        self.session.commit()
+
+        models.serializer.delete_resource(self.session, {}, 'users', 1)
+
+        post = self.session.query(models.Post).get(1)
+        comment = self.session.query(models.Comment).get(1)
+        self.assertEqual(post, None)
+        self.assertEqual(comment, None)


### PR DESCRIPTION
I added tests for delete_resource and delete_relationship. 
I flagged areas of no coverage.
The reason why I do not have coverage over these sections is because it would require changing the models. I want to play with sqlalchemy some more before I add new models or update the old ones.
