### PR TITLE
Add get relationship and get related tests

### DIFF
--- a/sqlalchemy_jsonapi/unittests/models.py
+++ b/sqlalchemy_jsonapi/unittests/models.py
@@ -43,7 +43,9 @@ class User(Base):
     # how we stored first internally in database.
     @attr_descriptor(AttributeActions.GET, 'first')
     def get_first_starts_with_get_attr(self):
-        return self.first[9::]
+        if 'SET-ATTR:' in self.first:
+            return self.first[9::]
+        return self.first
 
 
 class Post(Base):

--- a/sqlalchemy_jsonapi/unittests/test_serializer_get_collection.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_get_collection.py
@@ -106,7 +106,7 @@ class GetCollection(testcases.SqlalchemyJsonapiTestCase):
                     }
                 },
                 'attributes': {
-                    'content': 'This is a comment'
+                    'content': u'This is a comment'
                 }
             }],
             'included': [{
@@ -115,8 +115,8 @@ class GetCollection(testcases.SqlalchemyJsonapiTestCase):
                 'relationships': {
                     'posts': {
                         'links': {
-                            'self': '/users/1/relationships/post',
-                            'related': '/users/1/post'
+                            'self': '/users/1/relationships/posts',
+                            'related': '/users/1/posts'
                         }
                     },
                     'comments': {

--- a/sqlalchemy_jsonapi/unittests/test_serializer_get_related.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_get_related.py
@@ -150,7 +150,7 @@ class GetRelated(testcases.SqlalchemyJsonapiTestCase):
         self.assertEqual(200, response.status_code)
 
     def test_get_related_with_unknown_relationship(self):
-        """get related resource with unknown relationship returns 404.
+        """Get related resource with unknown relationship returns 404.
 
         A RelationshipNotFoundError is raised.
         """

--- a/sqlalchemy_jsonapi/unittests/test_serializer_get_related.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_get_related.py
@@ -1,0 +1,176 @@
+"""Test for serializer's get_related."""
+
+from sqlalchemy_jsonapi import errors
+
+from sqlalchemy_jsonapi.unittests.utils import testcases
+from sqlalchemy_jsonapi.unittests import models
+
+
+class GetRelated(testcases.SqlalchemyJsonapiTestCase):
+    """Tests for serializer.get_related."""
+
+    @testcases.fragile
+    def test_get_related_of_to_one(self):
+        """Get a related single resource returns a 200.
+
+        This test is fragile.
+        """
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        comment = models.Comment(
+            content='This is a comment', author_id=user.id,
+            post_id=blog_post.id, author=user, post=blog_post)
+        self.session.add(comment)
+        self.session.commit()
+
+        response = models.serializer.get_related(
+            self.session, {}, 'posts', blog_post.id, 'author')
+
+        expected = {
+            'data': {
+                'id': 1,
+                'type': 'users',
+                'included': {},
+                'relationships': {
+                    'comments': {
+                        'links': {
+                            'related': '/users/1/comments',
+                            'self': '/users/1/relationships/comments'
+                        }
+                    },
+                    'logs': {
+                        'links': {
+                            'related': '/users/1/logs',
+                            'self': '/users/1/relationships/logs'
+                        }
+                    },
+                    'posts': {
+                        'links': {
+                            'related': '/users/1/posts',
+                            'self': '/users/1/relationships/posts'
+                        }
+                    }
+                },
+                'attributes': {
+                    'first': u'Sally',
+                    'last': u'Smith',
+                    'username': u'SallySmith1'
+                }
+            },
+            'jsonapi': {
+                'version': '1.0'
+            },
+            'meta': {
+                'sqlalchemy_jsonapi_version': '4.0.9'
+            }
+        }
+        actual = response.data
+        self.assertEqual(expected, actual)
+        self.assertEqual(200, response.status_code)
+
+    def test_get_related_of_to_many(self):
+        """Get many related resource returns a 200."""
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        for x in (range(2)):
+            comment = models.Comment(
+                content='This is comment {0}'.format(x+1), author_id=user.id,
+                post_id=blog_post.id, author=user, post=blog_post)
+            self.session.add(comment)
+        self.session.commit()
+
+        response = models.serializer.get_related(
+            self.session, {}, 'posts', blog_post.id, 'comments')
+
+        expected = {
+            'data': [{
+                'id': 1,
+                'type': 'comments',
+                'included': {},
+                'relationships': {
+                    'post': {
+                        'links': {
+                            'self': '/comments/1/relationships/post',
+                            'related': '/comments/1/post'
+                        }
+                    },
+                    'author': {
+                        'links': {
+                            'self': '/comments/1/relationships/author',
+                            'related': '/comments/1/author'
+                        }
+                    }
+                },
+                'attributes': {
+                    'content': u'This is comment 1'
+                }
+            }, {
+                'id': 2,
+                'type': 'comments',
+                'included': {},
+                'relationships': {
+                    'post': {
+                        'links': {
+                            'self': '/comments/2/relationships/post',
+                            'related': '/comments/2/post'
+                        }
+                    },
+                    'author': {
+                        'links': {
+                            'self': '/comments/2/relationships/author',
+                            'related': '/comments/2/author'
+                        }
+                    }
+                },
+                'attributes': {
+                    'content': u'This is comment 2'
+                }
+            }],
+            'jsonapi': {
+                'version': '1.0'
+            },
+            'meta': {
+                'sqlalchemy_jsonapi_version': '4.0.9'
+            }
+        }
+        actual = response.data
+        self.assertEqual(expected, actual)
+        self.assertEqual(200, response.status_code)
+
+    def test_get_related_with_unknown_relationship(self):
+        """get related resource with unknown relationship returns 404.
+
+        A RelationshipNotFoundError is raised.
+        """
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        comment = models.Comment(
+            content='This is a comment', author_id=user.id,
+            post_id=blog_post.id, author=user, post=blog_post)
+        self.session.add(comment)
+        self.session.commit()
+
+        with self.assertRaises(errors.RelationshipNotFoundError) as error:
+            models.serializer.get_related(
+                self.session, {}, 'posts',
+                blog_post.id, 'invalid-relationship')
+
+        self.assertEqual(error.exception.status_code, 404)

--- a/sqlalchemy_jsonapi/unittests/test_serializer_get_relationship.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_get_relationship.py
@@ -1,0 +1,107 @@
+"""Test for serializer's get_relationship."""
+
+from sqlalchemy_jsonapi import errors
+
+from sqlalchemy_jsonapi.unittests.utils import testcases
+from sqlalchemy_jsonapi.unittests import models
+
+
+class GetRelationship(testcases.SqlalchemyJsonapiTestCase):
+    """Tests for serializer.get_relationship."""
+
+    def test_get_relationship_on_to_many(self):
+        """Get a relationship to many resources returns 200."""
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        for x in range(2):
+            comment = models.Comment(
+                content='This is comment {0}'.format(x+1), author_id=user.id,
+                post_id=blog_post.id, author=user, post=blog_post)
+            self.session.add(comment)
+        self.session.commit()
+
+        response = models.serializer.get_relationship(
+            self.session, {}, 'posts', blog_post.id, 'comments')
+
+        expected = {
+            'data': [{
+                'id': 1,
+                'type': 'comments'
+            }, {
+                'id': 2,
+                'type': 'comments'
+            }],
+            'jsonapi': {
+                'version': '1.0'
+            },
+            'meta': {
+                'sqlalchemy_jsonapi_version': '4.0.9'
+            }
+        }
+
+        actual = response.data
+        self.assertEqual(expected, actual)
+        self.assertEqual(200, response.status_code)
+
+    def test_get_relationship_on_to_one(self):
+        """Get a relationship of on to one returns 200."""
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        self.session.commit()
+
+        response = models.serializer.get_relationship(
+            self.session, {}, 'posts', blog_post.id, 'author')
+
+        expected = {
+            'data': {
+                'id': 1,
+                'type': 'users'
+            },
+            'jsonapi': {
+                'version': '1.0'
+            },
+            'meta': {
+                'sqlalchemy_jsonapi_version': '4.0.9'
+            }
+        }
+        actual = response.data
+        self.assertEqual(expected, actual)
+        self.assertEqual(200, response.status_code)
+
+    def test_get_relationship_with_unknown_relationship(self):
+        """Get a resources relationship with an unknown relationship returns 404.
+
+        A RelationshipNotFoundError is raised.
+        """
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content',
+            author_id=user.id, author=user)
+        self.session.add(blog_post)
+        comment = models.Comment(
+            content='This is a comment', author_id=user.id,
+            post_id=blog_post.id, author=user, post=blog_post)
+        self.session.add(comment)
+        self.session.commit()
+
+        with self.assertRaises(errors.RelationshipNotFoundError) as error:
+            models.serializer.get_relationship(
+                self.session, {}, 'posts',
+                blog_post.id, 'invalid-relationship')
+
+        self.assertEqual(error.exception.status_code, 404)


### PR DESCRIPTION
This PR adds tests for `get_relationship` and `get_related` tests. 
I also updated model file and then changed one get_collection test so that it will pass with new model change. 

Overall coverage is at 65% with the serializer.py file at 68%. 