### PR TITLE
Add two tests for testing when relationship object is null in realted_get and post_collection

### DIFF
--- a/sqlalchemy_jsonapi/unittests/test_serializer_get_related.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_get_related.py
@@ -174,3 +174,30 @@ class GetRelated(testcases.SqlalchemyJsonapiTestCase):
                 blog_post.id, 'invalid-relationship')
 
         self.assertEqual(error.exception.status_code, 404)
+
+    def test_get_related_when_related_object_is_null(self):
+        """Get a related object that is null returns 200."""
+        user = models.User(
+            first='Sally', last='Smith',
+            password='password', username='SallySmith1')
+        self.session.add(user)
+        blog_post = models.Post(
+            title='This Is A Title', content='This is the content')
+        self.session.add(blog_post)
+        self.session.commit()
+
+        response = models.serializer.get_related(
+            self.session, {}, 'posts', blog_post.id, 'author')
+
+        expected = {
+            'data': None,
+            'jsonapi': {
+                'version': '1.0'
+            },
+            'meta': {
+                'sqlalchemy_jsonapi_version': '4.0.9'
+            }
+        }
+        actual = response.data
+        self.assertEqual(expected, actual)
+        self.assertEqual(200, response.status_code)

--- a/sqlalchemy_jsonapi/unittests/test_serializer_post_collection.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_post_collection.py
@@ -503,3 +503,59 @@ class PostCollection(testcases.SqlalchemyJsonapiTestCase):
         self.assertEqual(
             error.exception.detail, 'posts must have type and id keys')
         self.assertEqual(error.exception.status_code, 400)
+
+    @testcases.fragile
+    def test_add_resource_with_a_null_relationship(self):
+        """Create resource with a null relationship returns 201."""
+        payload = {
+            'data': {
+                'type': 'posts',
+                'attributes': {
+                    'title': 'Some Title',
+                    'content': 'Some Content Inside'
+                },
+                'relationships': {
+                    'author': {
+                        'data': None
+                    }
+                }
+            }
+        }
+
+        response = models.serializer.post_collection(
+            self.session, payload, 'posts')
+
+        expected = {
+            'data': {
+                'type': 'posts',
+                'relationships': {
+                    'author': {
+                        'links': {
+                            'self': '/posts/1/relationships/author',
+                            'related': '/posts/1/author'
+                        }
+                    },
+                    'comments': {
+                        'links': {
+                            'self': '/posts/1/relationships/comments',
+                            'related': '/posts/1/comments'
+                        }
+                    }
+                },
+                'id': 1,
+                'attributes': {
+                    'title': u'Some Title',
+                    'content': u'Some Content Inside'
+                }
+            },
+            'jsonapi': {
+                'version': '1.0'
+            },
+            'meta': {
+                'sqlalchemy_jsonapi_version': '4.0.9'
+            },
+            'included': []
+        }
+        actual = response.data
+        self.assertEqual(expected, actual)
+        self.assertEqual(201, response.status_code)


### PR DESCRIPTION
This PR is very small and adds two tests that deal with when a relationship object is null in related_get and post_collection. These tests add coverage to two lines of code that we did not have before. Once again these are very small. 