### PR TITLE
Add test to verify that an invalid json payload results in a BadRequestError

### DIFF
--- a/sqlalchemy_jsonapi/unittests/test_serializer_post_collection.py
+++ b/sqlalchemy_jsonapi/unittests/test_serializer_post_collection.py
@@ -503,3 +503,18 @@ class PostCollection(testcases.SqlalchemyJsonapiTestCase):
         self.assertEqual(
             error.exception.detail, 'posts must have type and id keys')
         self.assertEqual(error.exception.status_code, 400)
+
+    def test_add_resource_with_invalid_json_payload(self):
+        """Create resource with invalid json payload returns 400.
+
+        A BadRequestError is raised.
+        """
+        payload = {'foo'}
+
+        with self.assertRaises(errors.BadRequestError) as error:
+            models.serializer.post_collection(
+                self.session, payload, 'users')
+
+        self.assertEqual(
+            error.exception.detail, 'Request body should be a JSON hash')
+        self.assertEqual(error.exception.status_code, 400)


### PR DESCRIPTION
This is a single test that verifies that sending a request with an invalid json payload results in a BadRequestError. This test added one more line of code coverage. 