### PR TITLE
Add user_error functionality so a user may create a custom jsonapi compliant error response.

### DIFF
--- a/sqlalchemy_jsonapi/errors.py
+++ b/sqlalchemy_jsonapi/errors.py
@@ -1,3 +1,4 @@
+import json
 from uuid import uuid4
 
 
@@ -137,3 +138,29 @@ class ResourceTypeNotFoundError(BaseError):
         tmpl = 'This backend has not been configured to handle resources of '\
             'type {}.'
         self.detail = tmpl.format(api_type)
+
+
+def user_error(status_code, title, detail, pointer):
+    """Create and return a general user error response that is jsonapi compliant.
+
+    Args:
+        status_code: The HTTP status code associated with the problem.
+        title: A short summary of the problem.
+        detail: An explanation specific to the occurence of the problem.
+        pointer: The request path associated with the source of the problem.
+    """
+    response = {
+        'errors': [{
+            'status': status_code,
+            'source': {'pointer': '{0}'.format(pointer)},
+            'title': title,
+            'detail': detail,
+        }],
+        'jsonapi': {
+            'version': '1.0'
+        },
+        'meta': {
+            'sqlalchemy_jsonapi_version': '4.0.9'
+        }
+    }
+    return json.dumps(response), status_code

--- a/sqlalchemy_jsonapi/errors.py
+++ b/sqlalchemy_jsonapi/errors.py
@@ -143,7 +143,7 @@ class ResourceTypeNotFoundError(BaseError):
 def user_error(status_code, title, detail, pointer):
     """Create and return a general user error response that is jsonapi compliant.
 
-    Args:
+    Required args:
         status_code: The HTTP status code associated with the problem.
         title: A short summary of the problem.
         detail: An explanation specific to the occurence of the problem.

--- a/sqlalchemy_jsonapi/unittests/test_errors_user_error.py
+++ b/sqlalchemy_jsonapi/unittests/test_errors_user_error.py
@@ -1,0 +1,37 @@
+"""Test for error's user_error."""
+
+import json
+import unittest
+
+from sqlalchemy_jsonapi import errors
+
+
+class TestUserError(unittest.TestCase):
+    """Tests for errors.user_error."""
+
+    def test_user_error(self):
+        """Create user error succesfully."""
+        status_code = 400
+        title = 'User Error Occured'
+        detail = 'Testing user error'
+        pointer = '/test'
+
+        actual = errors.user_error(
+            status_code, title, detail, pointer)
+
+        data = {
+            'errors': [{
+                'status': status_code,
+                'source': {'pointer': '{0}'.format(pointer)},
+                'title': title,
+                'detail': detail,
+            }],
+            'jsonapi': {
+                'version': '1.0'
+            },
+            'meta': {
+                'sqlalchemy_jsonapi_version': '4.0.9'
+            }
+        }
+        expected = json.dumps(data), status_code
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
This PR creates a function `user_error` that returns a custom error response that is jsonapi compliant. 
Users can use this to create custom errors relating to
* status_code
* title
* detail
* pointer
Please note status_code, title, detail, and pointer are all required. 